### PR TITLE
Run mvn evaluate once before attempting to parse the version

### DIFF
--- a/release-script/booster-release.sh
+++ b/release-script/booster-release.sh
@@ -11,6 +11,9 @@ if ((`git status -sb | wc -l` != 1)); then
     exit 1
 fi
 
+# run mvn help:evaluate once first since it often needs to download stuff which screws up version parsing
+mvn help:evaluate -Dexpression=project.version > /dev/null
+
 # check that we have proper git information to automatically commit and push
 # git status -sb has the following format: ## master...upstream/master when tracking a remote branch
 GIT_STATUS=`git status -sb`


### PR DESCRIPTION
Because I often find that it needs to download stuff and it screws up version parsing.